### PR TITLE
ci: add job to automatically update bundled mp Android & iOS SDKs

### DIFF
--- a/.github/workflows/update-sdks.yml
+++ b/.github/workflows/update-sdks.yml
@@ -1,0 +1,52 @@
+name: "Update SDKs"
+
+on: 
+  workflow_dispatch:
+    inputs:
+      branch-name:
+        description: "Output branch name"
+        required: true
+        default: "update-android-sdk"
+
+jobs:
+  update-android-sdk:
+    name: "Update Android SDK"
+    runs-on: ubuntu-latest
+    env:
+      GIT_AUTHOR_NAME: mparticle-bot
+      GIT_AUTHOR_EMAIL: developers@mparticle.com
+      GIT_COMMITTER_NAME: mparticle-bot
+      GIT_COMMITTER_EMAIL: developers@mparticle.com
+    steps:
+      - name: "Download Android Maven Metadata"
+        run: curl https://repo1.maven.org/maven2/com/mparticle/android-core/maven-metadata.xml -o maven-metadata.xml
+      - name: "Parse Latest Version"
+        id: latest-version
+        uses: QwerMike/xpath-action@v1
+        with:
+          filename: 'maven-metadata.xml'
+          expression: '//versioning/latest/text()'
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: "Download Maven Artifact"
+        id: download-maven-artifact
+        uses: clausnz/github-action-download-maven-artifact@master
+        with:
+          url: 'https://repo1.maven.org'
+          repository: 'maven2'
+          groupId: 'com.mparticle'
+          artifactId: 'android-core'
+          version: ${{steps.latest-version.outputs.result}}
+          extension: 'aar'
+          # https://repo1.maven.org/maven2/com/mparticle/android-core/5.37.0/android-core-5.37.0.jar
+      - name: "Output file path in container"
+        run: |
+          jar xf ${{steps.download-maven-artifact.outputs.file}} classes.jar
+          mv -f classes.jar Assets/Plugins/Android/mparticle-core.jar
+      - name: "Commit Changes"
+        run: |
+          git add Assets/Plugins/Android
+          git diff-index --quiet HEAD || git commit -m "update: mParticle Android SDK to version ${{steps.latest-version.outputs.result}}"; git push origin HEAD:${{github.event.inputs.branch-name}}

--- a/.github/workflows/update-sdks.yml
+++ b/.github/workflows/update-sdks.yml
@@ -1,12 +1,9 @@
 name: "Update SDKs"
 
 on: 
+  schedule:
+    - cron:  '00 15 * * 1'
   workflow_dispatch:
-    inputs:
-      branch-name:
-        description: "Output branch name"
-        required: true
-        default: "update-android-sdk"
 
 jobs:
   update-android-sdk:
@@ -41,7 +38,6 @@ jobs:
           artifactId: 'android-core'
           version: ${{steps.latest-version.outputs.result}}
           extension: 'aar'
-          # https://repo1.maven.org/maven2/com/mparticle/android-core/5.37.0/android-core-5.37.0.jar
       - name: "Output file path in container"
         run: |
           jar xf ${{steps.download-maven-artifact.outputs.file}} classes.jar
@@ -49,4 +45,33 @@ jobs:
       - name: "Commit Changes"
         run: |
           git add Assets/Plugins/Android
-          git diff-index --quiet HEAD || git commit -m "update: mParticle Android SDK to version ${{steps.latest-version.outputs.result}}"; git push origin HEAD:${{github.event.inputs.branch-name}}
+          git diff-index --quiet HEAD || git commit -m "update: mParticle Android SDK to version ${{steps.latest-version.outputs.result}}"; git push -f origin HEAD:update-sdks
+  update-apple-sdk:
+    needs: update-android-sdk
+    name: "Update iOS SDK"
+    runs-on: macos-latest
+    env:
+      GIT_AUTHOR_NAME: mparticle-bot
+      GIT_AUTHOR_EMAIL: developers@mparticle.com
+      GIT_COMMITTER_NAME: mparticle-bot
+      GIT_COMMITTER_EMAIL: developers@mparticle.com
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          ref: update-sdks
+          fetch-depth: 0
+          lfs: true
+      - name: "Create Cartfile"
+        run: echo "github \"mparticle/mparticle-apple-sdk\"" > Cartfile
+      - name: "Carthage Install"
+        run: carthage update
+      - name: "Move mParticle-apple-sdk.framework"
+        run: |
+          rm -rf Assets/Plugins/iOS/mParticle_Apple_SDK.framework; 
+          mv -f carthage/Build/iOS/mParticle_Apple_SDK.framework Assets/Plugins/iOS/
+      - name: "Commit Changes"
+        run: |
+          git add Assets/Plugins/iOS
+          git diff-index --quiet HEAD || git commit -m "update: mParticle Apple SDK to version $(cut -d'"' -f2 <<< `carthage checkout`)"; git push origin HEAD:update-sdks

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.32f1
-m_EditorVersionWithRevision: 2020.3.32f1 (12f8b0834f07)
+m_EditorVersion: 2020.3.0f1
+m_EditorVersionWithRevision: 2020.3.0f1 (c7b5465681fb)

--- a/buildscript.sh
+++ b/buildscript.sh
@@ -4,7 +4,7 @@
 
 project_dir=${PWD}
 
-/Applications/Unity/Hub/Editor/2020.3.32f1/Unity.app/Contents/MacOS/Unity \
+/Applications/Unity/Hub/Editor/2020.3.0f1/Unity.app/Contents/MacOS/Unity \
     -projectPath "${PWD}" \
     -logFile \
     -exportPackage Assets/mParticle/MParticle.cs \


### PR DESCRIPTION
# Summary

Add a job for updating each of the Android and iOS SDKs. This job will be run weekly on Mondays as part of a chron job, but can also be triggered manually.

The job will push 2 seperate commits for each platform to the branch `update-kits` and overwrite any branch  with that name. After generating this branch we can open a PR and merge it


Successful Job (with `push` trigger added for testing): https://github.com/mParticle/mparticle-unity-plugin/actions/runs/2068066503
Generated Branch: https://github.com/mParticle/mparticle-unity-plugin/tree/update-sdks