### PR TITLE
ci: add workflow checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Instructions
+1. PR target branch should be against main
+2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/stable/.github/workflows/pr-title-check.yml
+3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/stable/.github/workflows/pr-branch-check-name.yml
+
+## Summary
+- {provide a thorough description of the changes}
+
+## Testing Plan
+- {explain how this has been tested, and what additional testing should be done}
+
+## Master Issue
+- Closes https://go.mparticle.com/work/REPLACEME

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,10 +1,24 @@
-name: Build project
+name: Checks
 
 on: [push, pull_request]
 
 jobs:
+  pr-branch-check-name:
+    name: "Check PR for semantic branch name"
+    if: ${{ github.event.pull_request }}
+    uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-check-name.yml@stable
+  pr-title-check:
+    name: "Check PR for semantic title"
+    if: ${{ github.event.pull_request }}
+    uses: mParticle/mparticle-workflows/.github/workflows/pr-title-check.yml@stable
+  pr-branch-target-gitflow:
+    name: "Check PR for semantic target branch"
+    if: ${{ github.event.pull_request }}
+    uses: mParticle/mparticle-workflows/.github/workflows/pr-branch-target-continuous.yml@stable
   buildForAllSupportedPlatforms:
     name: Build for ${{ matrix.targetPlatform }}
+    needs: [pr-branch-check-name, pr-title-check, pr-branch-target-gitflow]
+    if: always() && !failure()
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Add reusable workflow checks from 

## Testing Plan
- Build tests still run on push
- Build tests don't run when PR checks fail, on pull request
- Build tests do run when PR checks pass,on pull request

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-3620

