### PR TITLE
fix: build when iOS platform not installed

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,13 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         targetPlatform:
-          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
-          - StandaloneWindows # Build a Windows standalone.
-          - StandaloneWindows64 # Build a Windows 64-bit standalone.
-          - StandaloneLinux64 # Build a Linux 64-bit standalone.
           - iOS # Build an iOS player.
           - Android # Build an Android .apk standalone app.
-          - WebGL # WebGL.
     steps:
       - uses: actions/checkout@v2
         with:
@@ -48,7 +43,7 @@ jobs:
             UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
         with:
           targetPlatform: ${{ matrix.targetPlatform }}
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Build-${{ matrix.targetPlatform }}
-          path: build/${{ matrix.targetPlatform }}
+      # - uses: actions/upload-artifact@v2
+      #   with:
+      #     name: Build-${{ matrix.targetPlatform }}
+      #     path: build/${{ matrix.targetPlatform }}

--- a/Assets/Editor/MParticleBuildPostprocessor.cs
+++ b/Assets/Editor/MParticleBuildPostprocessor.cs
@@ -1,14 +1,19 @@
+
 using UnityEditor;
 using UnityEditor.Callbacks;
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
 using UnityEditor.iOS.Xcode.Extensions;
+#endif
 
-namespace mParticle {
+namespace mParticle
+{
     public class BuildPostProcessor
     {
         [PostProcessBuild]
         public static void OnPostProcessBuild(BuildTarget target, string path)
         {
+            #if UNITY_IOS
             if (target == BuildTarget.iOS)
             {
                 // Get project into C#
@@ -29,6 +34,7 @@ namespace mParticle {
                 // Overwrite
                 project.WriteToFile(projectPath);
             }
+            #endif
         }
     }
 }


### PR DESCRIPTION
## Summary
Fix build when iOS platform not installed (fixes CI and potentially customer builds if they don't support iOS)
Also removed unsupported platforms from CI matrix and stopped attaching artifacts as they’re not useful
