### PR TITLE
fix: build fails when IL2CCP enabled

### DIFF
--- a/Assets/mParticle/MParticle.cs
+++ b/Assets/mParticle/MParticle.cs
@@ -5,8 +5,7 @@ using System.Linq;
 
 #if UNITY_ANDROID
 using mParticleAndroid;
-#endif
-#if UNITY_IOS
+#elif UNITY_IOS
 using mParticleiOs;
 #endif
 

--- a/Assets/mParticle/MParticleAndroid.cs
+++ b/Assets/mParticle/MParticleAndroid.cs
@@ -8,6 +8,7 @@ using mParticle;
 
 namespace mParticleAndroid
 {
+	#if UNITY_ANDROID
 	public sealed class MParticleAndroid : IMParticleSDK
 	{
 		private AndroidJavaObject mp;
@@ -454,4 +455,5 @@ namespace mParticleAndroid
 		}
 
 	}
+	#endif
 }

--- a/Assets/mParticle/MParticleiOS.cs
+++ b/Assets/mParticle/MParticleiOS.cs
@@ -9,6 +9,7 @@ using System.Linq;
 
 namespace mParticleiOs
 {
+	#if UNITY_IOS
 	public class MParticleiOS : IMParticleSDK
 	{
 		/*
@@ -639,4 +640,5 @@ namespace mParticleiOs
 		}
 
 	}
+	#endif
 }


### PR DESCRIPTION
## Summary
- When IL2CCP is enabled, Unity will compile _all_ the files, in the context of the target platform. Since `MParticleiOS` will be compiled for Android builds and `MParticleAndroid` for iOS builds, the missing corresponding SDK artifacts were causing a variety of build and runtime errors.

I took the simple approach of wrapping each platform specific class in an `#if UNITY_{platform}` conditional, but there might be a more elegant way that I am unaware of :)

## Testing Plan
- ran repro app, eveything looks good. I would like to follow this up with a test that solidifies this fix in CI

## Master Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4186
